### PR TITLE
keyfn bug fix + cljs deps update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,15 @@
-(defproject tailrecursion/cljs-priority-map "1.1.0"
+(defproject tailrecursion/cljs-priority-map "1.1.1-SNAPSHOT"
   :description "ClojureScript priority map implementation based on clojure.data.priority-map"
   :url "https://github.com/tailrecursion/cljs-priority-map"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojurescript "1.7.170"]]
   :source-paths ["src/cljs"]
-  :plugins [[lein-cljsbuild "1.0.3"]]
+  :plugins [[lein-cljsbuild "1.1.1"]]
   :cljsbuild {:builds {:test
                        {:source-paths ["test"]
-                        :dependencies [[org.clojure/clojurescript "0.0-2156"]]
                         :compiler {:output-to "public/test.js"
                                    :optimizations :advanced}
-                        :jar false}}})
+                        :jar false}}
+              :test-commands {"phantomjs" ["phantomjs" "public/test.js"]}})

--- a/src/cljs/tailrecursion/priority_map.cljs
+++ b/src/cljs/tailrecursion/priority_map.cljs
@@ -34,7 +34,7 @@
 
   IHash
   (-hash [this]
-    (coreclj/caching-hash this core/hash-imap __hash))
+    (coreclj/caching-hash this core/hash-unordered-coll __hash))
 
   ISeqable
   (-seq [this]
@@ -109,8 +109,8 @@
              nil)
             (PersistentPriorityMap.
              (assoc priority->set-of-items
-               current-priority (disj (get priority->set-of-items current-priority-key) item)
-               priority (conj (get priority->set-of-items priority-key #{}) item))
+                    current-priority-key (disj (get priority->set-of-items current-priority-key) item)
+                    priority-key (conj (get priority->set-of-items priority-key #{}) item))
              (assoc item->priority item priority)
              meta
              keyfn


### PR DESCRIPTION
Hi, this is a fix for the issue #5.
The bug arises when you try to replace an entry on a priority-map-keyfn of size > 1.
The priority->set-of-items was updated with the priority instead of the key, hence the error.
Please note that due to the old clojurescript dependency I didn't manage to run the test so I had to update clojurescript and lein-cljsbuild deps in project.clj. As the hashing strategy for maps has changed since then I had to update the -hash method as well.
All tests pass with phantomjs.